### PR TITLE
add rg variable to cd template

### DIFF
--- a/captainkube/cd-pipeline.yml
+++ b/captainkube/cd-pipeline.yml
@@ -24,7 +24,7 @@ stages:
   - deployment: development
     variables:
       k8sNamespace: 'phippyandfriends'
-      # define 4 more variables: aks, aksSpId, aksSpSecret and aksSpTenantId in the Azure pipeline UI definition
+      # define 5 more variables: aks, rg, aksSpId, aksSpSecret and aksSpTenantId in the Azure pipeline UI definition
     displayName: deploy helm chart into AKS
     pool:
       vmImage: 'ubuntu-16.04'

--- a/common/cd-steps-template.yml
+++ b/common/cd-steps-template.yml
@@ -14,7 +14,7 @@ steps:
         --tenant $(aksSpTenantId)
     az aks get-credentials \
         -n $(aks) \
-        -g $(aks)
+        -g $(rg)
     helm repo add \
         $(registryName) \
         https://$(registryServerName)/helm/v1/repo \

--- a/nodebrady/cd-pipeline.yml
+++ b/nodebrady/cd-pipeline.yml
@@ -24,7 +24,7 @@ stages:
   - deployment: development
     variables:
       k8sNamespace: 'phippyandfriends'
-      # define 4 more variables: aks, aksSpId, aksSpSecret and aksSpTenantId in the Azure pipeline UI definition
+      # define 5 more variables: aks, rg, aksSpId, aksSpSecret and aksSpTenantId in the Azure pipeline UI definition
     displayName: deploy helm chart into AKS
     pool:
       vmImage: 'ubuntu-16.04'

--- a/parrot/cd-pipeline.yml
+++ b/parrot/cd-pipeline.yml
@@ -24,7 +24,7 @@ stages:
   - deployment: development
     variables:
       k8sNamespace: 'phippyandfriends'
-      # define 4 more variables: aks, aksSpId, aksSpSecret and aksSpTenantId in the Azure pipeline UI definition
+      # define 5 more variables: aks, rg, aksSpId, aksSpSecret and aksSpTenantId in the Azure pipeline UI definition
     displayName: deploy helm chart into AKS
     pool:
       vmImage: 'ubuntu-16.04'

--- a/phippy/cd-pipeline.yml
+++ b/phippy/cd-pipeline.yml
@@ -24,7 +24,7 @@ stages:
   - deployment: development
     variables:
       k8sNamespace: 'phippyandfriends'
-      # define 4 more variables: aks, aksSpId, aksSpSecret and aksSpTenantId in the Azure pipeline UI definition
+      # define 5 more variables: aks, rg, aksSpId, aksSpSecret and aksSpTenantId in the Azure pipeline UI definition
     displayName: deploy helm chart into AKS
     pool:
       vmImage: 'ubuntu-16.04'


### PR DESCRIPTION
Hi there!

I was following your excellent tutorial here:
https://cloudblogs.microsoft.com/opensource/2018/11/27/tutorial-azure-devops-setup-cicd-pipeline-kubernetes-docker-helm

When trying to deploy the CD pipeline, something went wrong: the az cli wasn't able to login. After some digging I found that this is because you named your Azure resource group the same as your cluster. I'd suggest this change and also an update in the tutorial where you add an extra variable `rg` to the pipeline.