### PR TITLE
fixing cd directory name for getting started - clone the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The Phippy and Friends repository is public. Just clone it to your local machine
 
 ```bash
 git clone https://github.com/Azure/phippyandfriends.git
-cd phippy-demo
+cd phippyandfriends
 code .
 ```
 


### PR DESCRIPTION
Noticed this while attempting the demo